### PR TITLE
Links that has been selected in 'copySelection' generate a URL instead of href string.

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -22,7 +22,7 @@ document.addEventListener("contextmenu", function (event) {
     links = [];
     linksInSelection.each(function() {
       links.push({
-        href: $(this).attr('href'),
+        href: $(this).prop('href'),
         text: $(this).text(),
         src:  $(this).find('img').attr('src')
       });


### PR DESCRIPTION
Selected string ( that have some links ) generate href string.

```
<a href="function.array-change-key-case.php">array_change_key_case</a>
```

ex.
```

- [array_change_key_case](function.array-change-key-case.php)
- [array_chunk](function.array-chunk.php)
```

Those links expect URLs.
ex.
```
> - [array_change_key_case](http://php.net/manual/en/function.array-change-key-case.php)
> - [array_chunk](http://php.net/manual/en/function.array-chunk.php)
```

`prop('href')` generate URL string from href attribute.
