### PR TITLE
Fix a link string may become the "undefined".

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -9,7 +9,7 @@ document.addEventListener("contextmenu", function (event) {
 
   var linksInSelection = 0;
   var text;
-  if (selection.rangeCount == 0) {
+  if (selection.rangeCount == 0 || selection.type === "Caret") {
     text = $(event.target).text() || $(event.target).parent().text()
   } else {
     var clonedSelection = selection.getRangeAt(0).cloneContents();


### PR DESCRIPTION
Sometimes, it may link string is "undefined".

ex.
```
[undefined](http://php.net/manual/ja/function.array-change-key-case.php)
```

If selection.type is "Caret", ignore selection.rangeCount and using "$(event.target).text()".
